### PR TITLE
fix: change Dependabot to weekly schedule for supply chain protection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: 'weekly'
     groups:
       debian:
         patterns:


### PR DESCRIPTION
## Summary
- Changes Dependabot schedule from `daily` to `weekly`

## Why
Supply chain protection. Dependabot lacks a `minimumReleaseAge` setting, so switching to weekly provides a buffer against auto-merging recently-published compromised packages. Weekly schedule ensures at least several days pass before packages are picked up.